### PR TITLE
fix(crash): Disabled sentry session replay. It was causing a crash on…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ index.js
 node_modules/
 package-lock.json
 package.json
+app/release
 
 # Sentry Config File
 sentry.properties

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -72,8 +72,10 @@
     <!-- enable profiling when starting transactions, adjust in production env -->
     <meta-data android:name="io.sentry.traces.profiling.sample-rate" android:value="1.0" />
     <!-- enable session replay -->
-    <meta-data android:name="io.sentry.session-replay.on-error-sample-rate" android:value="1.0" />
-    <meta-data android:name="io.sentry.session-replay.session-sample-rate" android:value="0.0" />
+    <!-- Session replay is causing a crash on some devices.
+    We'll disable it for now as it's a new unstable feature. -->
+    <!--    <meta-data android:name="io.sentry.session-replay.on-error-sample-rate" android:value="1.0" />-->
+    <!--    <meta-data android:name="io.sentry.session-replay.session-sample-rate" android:value="0.0" />-->
 
     </application>
 


### PR DESCRIPTION
… some devices. Perhaps we'll re-enable it in the future when the feature becomes stable.